### PR TITLE
Debug vercel __dirname not defined error

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,6 @@
 const nextConfig = {
   experimental: {
     typedRoutes: true,
-    serverComponentsExternalPackages: ['pdf-parse'],
   },
   eslint: {
     dirs: ['src'],

--- a/src/pdf/parsePdf.ts
+++ b/src/pdf/parsePdf.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import pdfParse, { PDFInfo } from 'pdf-parse';
 import { CONTAMINANT_CATEGORY_MAP, ContaminantRecord, PdfExtractionResult } from './types';
 
 interface ParseOptions {
@@ -252,6 +251,9 @@ export async function parsePdf(options: ParseOptions): Promise<PdfExtractionResu
     throw new Error('Either filePath or buffer must be provided');
   }
 
+  // Dynamic import to prevent build-time execution
+  const { default: pdfParse } = await import('pdf-parse');
+  
   const fileBuffer = buffer ?? (await fs.readFile(path.resolve(filePath!)));
   const result = await pdfParse(fileBuffer);
 
@@ -329,7 +331,7 @@ export async function parsePdf(options: ParseOptions): Promise<PdfExtractionResu
   return {
     metadata: {
       fileName: options.fileName ?? (filePath ? path.basename(filePath) : 'uploaded.pdf'),
-      pageCount: (info as PDFInfo | undefined)?.Pages ?? 0
+      pageCount: (info as any)?.Pages ?? 0
     },
     contaminants,
     rawText: text,


### PR DESCRIPTION
Resolve `__dirname is not defined` error on Vercel by dynamically importing `pdf-parse` and removing it from external packages.

The `pdf-parse` library's debug code was executing during the Next.js build process, causing a `ReferenceError: __dirname is not defined` and a build failure due to attempting to read a non-existent test file. Dynamic import ensures `pdf-parse` is only loaded at runtime, bypassing this build-time issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-33e87a88-352c-4874-ba48-4609b383052d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33e87a88-352c-4874-ba48-4609b383052d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

